### PR TITLE
Simplify cmake (#28)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,114 +1,159 @@
-cmake_minimum_required(VERSION 2.8.11)
-project (noise)
+cmake_minimum_required(VERSION 3.5)
 
-include_directories(include src)
+set(PROJECT_NAME MiniFB)
+project(${PROJECT_NAME})
 
-file(GLOB SrcLib       "src/*.c" 
-                       "src/*.cpp" 
-                       "src/*.h"
-                       "include/*.h")
-file(GLOB SrcWindows   "src/windows/*.c" 
-                       "src/windows/*.h")
-file(GLOB SrcMacOSX    "src/macosx/*.c" 
-                       "src/macosx/*.cpp" 
-                       "src/macosx/*.m" 
-                       "src/macosx/*.mm" 
-                       "src/macosx/*.h")
-file(GLOB SrcWayland   "src/wayland/*.c")
-file(GLOB SrcX11       "src/x11/*.c")
+message("Processing " ${PROJECT_NAME})
 
+set(SrcLib
+    include/MiniFB.h
+    include/MiniFB_cpp.h
+    include/MiniFB_enums.h
+
+    src/MiniFB_common.c
+    src/MiniFB_cpp.cpp
+    src/MiniFB_internal.c
+    src/MiniFB_internal.h
+    src/WindowData.h
+)
+
+set(SrcWindows
+    src/windows/WinMiniFB.c
+    src/windows/WindowData_Win.h
+)
+
+set(SrcMacOSX
+    src/macosx/MacMiniFB.m
+    src/macosx/OSXWindow.h
+    src/macosx/OSXWindow.m
+    src/macosx/OSXWindowFrameView.h
+    src/macosx/OSXWindowFrameView.m
+    src/macosx/WindowData_OSX.h
+)
+
+set(SrcWayland
+    src/wayland/WaylandMiniFB.c
+    src/wayland/WindowData_Way.h
+)
+
+set(SrcX11
+    src/x11/X11MiniFB.c
+    src/x11/WindowData_X11.h
+)
+
+# Avoid RelWithDebInfo and MinSizeRel
+#--------------------------------------
+set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "" FORCE)
+
+# Define Release by default
+#--------------------------------------
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Release")
+    message(STATUS "Build type not specified: Use Release by default")
+endif(NOT CMAKE_BUILD_TYPE)
+
+# Set GCC/Clang flags
+#--------------------------------------
 if (NOT MSVC)
-    set (CMAKE_C_FLAGS "-g -Wall -Wextra -pedantic -Wno-switch -Wno-unused-function -Wno-implicit-fallthrough")
+    # Avoid default flag values
+    #--------------------------------------
+    set(CMAKE_C_FLAGS "" CACHE STRING "" FORCE)
+    set(CMAKE_C_FLAGS_DEBUG "" CACHE STRING "" FORCE)
+    set(CMAKE_C_FLAGS_RELEASE "" CACHE STRING "" FORCE)
+
+    set(CMAKE_CXX_FLAGS "" CACHE STRING "" FORCE)
+    set(CMAKE_CXX_FLAGS_DEBUG "" CACHE STRING "" FORCE)
+    set(CMAKE_CXX_FLAGS_RELEASE "" CACHE STRING "" FORCE)
+
+    set(CMAKE_OBJC_FLAGS "" CACHE STRING "" FORCE)
+    set(CMAKE_OBJC_FLAGS_DEBUG "" CACHE STRING "" FORCE)
+    set(CMAKE_OBJC_FLAGS_RELEASE "" CACHE STRING "" FORCE)
+
+    set(CMAKE_OBJCXX_FLAGS "" CACHE STRING "" FORCE)
+    set(CMAKE_OBJCXX_FLAGS_DEBUG "" CACHE STRING "" FORCE)
+    set(CMAKE_OBJCXX_FLAGS_RELEASE "" CACHE STRING "" FORCE)
+
+    # Set our flags
+    #--------------------------------------
+    add_compile_options("$<$<CONFIG:Debug>:-g>")
+    add_compile_options("$<IF:$<CONFIG:Debug>,-O0,-O2>")
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -pedantic -Wno-switch -Wno-unused-function -Wno-implicit-fallthrough")
     set (CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -std=c++11")
     set (CMAKE_OBJC_FLAGS "${CMAKE_C_FLAGS}")
     set (CMAKE_OBJCXX_FLAGS "${CMAKE_CXX_FLAGS}")
 endif()
 
+# Set default cmake flags
+#--------------------------------------
 if (APPLE) 
     OPTION(USE_METAL_API "Build the project using metal API code" ON)
 elseif (UNIX)
     OPTION(USE_WAYLAND_API "Build the project using wayland API code" OFF)
 endif()
 
+# Set compiler/platform specific flags and dependencies
+#--------------------------------------
 if (MSVC)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
     add_definitions(-D_WIN32_WINNT=0x0600)
+
     list (APPEND SrcLib ${SrcWindows})
 elseif (MINGW)
     add_definitions(-D_WIN32_WINNT=0x0600)
+
     list(APPEND SrcLib ${SrcWindows})
 elseif (APPLE)
     if(USE_METAL_API)
         add_definitions(-DUSE_METAL_API)
     endif()
+    
+    link_libraries("-framework Cocoa")
+    link_libraries("-framework QuartzCore")
+    link_libraries("-framework Metal")
+    link_libraries("-framework MetalKit")
+    
     list(APPEND SrcLib ${SrcMacOSX})
 elseif (UNIX)
     if(USE_WAYLAND_API)
+        link_libraries("-lwayland-client")
+        link_libraries("-lwayland-cursor")
+
         list(APPEND SrcLib ${SrcWayland})
     else()
+        link_libraries("-lX11")
+
         list(APPEND SrcLib ${SrcX11})
     endif()
 endif()
 
+# Library
+#--------------------------------------
 add_library(minifb STATIC 
     ${SrcLib}
 )
 
+# For all projects
+#--------------------------------------
+target_include_directories(minifb PUBLIC  include)
+target_include_directories(minifb PRIVATE src)
+link_libraries(minifb)
+
+# Examples
+#--------------------------------------
 add_executable(noise 
     tests/noise.c
 )
-target_link_libraries(noise minifb)
 
 add_executable(input_events 
     tests/input_events.c
 )
-target_link_libraries(input_events minifb)
 
 add_executable(input_events_cpp
     tests/input_events_cpp.cpp
 )
-target_link_libraries(input_events_cpp minifb)
 
 add_executable(multiple_windows
     tests/multiple_windows.c
 )
-target_link_libraries(multiple_windows minifb)
 
-if (MSVC)
-elseif (MINGW)
-elseif (APPLE)
-    target_link_libraries(noise "-framework Cocoa")
-    target_link_libraries(noise "-framework QuartzCore")
-    target_link_libraries(noise "-framework Metal")
-    target_link_libraries(noise "-framework MetalKit")
-
-    target_link_libraries(input_events "-framework Cocoa")
-    target_link_libraries(input_events "-framework QuartzCore")
-    target_link_libraries(input_events "-framework Metal")
-    target_link_libraries(input_events "-framework MetalKit")
-    target_link_libraries(input_events_cpp "-framework Cocoa")
-    target_link_libraries(input_events_cpp "-framework QuartzCore")
-    target_link_libraries(input_events_cpp "-framework Metal")
-    target_link_libraries(input_events_cpp "-framework MetalKit")
-
-    target_link_libraries(multiple_windows "-framework Cocoa")
-    target_link_libraries(multiple_windows "-framework QuartzCore")
-    target_link_libraries(multiple_windows "-framework Metal")
-    target_link_libraries(multiple_windows "-framework MetalKit")
-elseif (UNIX)
-    if(USE_WAYLAND_API)
-        target_link_libraries(noise -lwayland-client -lwayland-cursor)
-
-        target_link_libraries(input_events -lwayland-client -lwayland-cursor)
-        target_link_libraries(input_events_cpp -lwayland-client -lwayland-cursor)
-
-        target_link_libraries(multiple_windows -lwayland-client -lwayland-cursor)
-    else()
-        target_link_libraries(noise -lX11)
-
-        target_link_libraries(input_events -lX11)
-        target_link_libraries(input_events_cpp -lX11)
-
-        target_link_libraries(multiple_windows -lX11)
-    endif()
-endif()
+message("Done " ${PROJECT_NAME})


### PR DESCRIPTION
* update documentation

* Fix typo

* Added some examples

* changed window names

* Minor fix

* Added mfb_update_events to all platforms. Checked on Windows, X11 and Wayland

* simplify CMake

* Upgrade to CMake 3.5, simplify script and generalize it
Now the users only have to add_directory and link_libraries(minifb) in CMake