### PR TITLE
Fix shader warning for macOS Catalina (#30)

### DIFF
--- a/src/macosx/MacMiniFB.m
+++ b/src/macosx/MacMiniFB.m
@@ -55,7 +55,7 @@ NSString* g_shadersSrc = @
         "float4 position [[position]];\n"
     "};\n"
 
-    "vertex VertexOutput vertFunc2(unsigned int vID[[vertex_id]], device Vertex *pos [[buffer(0)]])\n"
+    "vertex VertexOutput vertFunc2(unsigned int vID[[vertex_id]], const device Vertex *pos [[buffer(0)]])\n"
     "{\n"
         "VertexOutput out;\n"
 


### PR DESCRIPTION
In Catalina, shader creation will fail because of the following issue:

```
Compilation succeeded with:

program_source:22:21: warning: writable resources in non-void vertex function
vertex VertexOutput vertFunc2(unsigned int vID[[vertex_id]], device Vertex *pos [[buffer(0)]])
                    ^
program_source:22:77: note: writable buffer defined here
vertex VertexOutput vertFunc2(unsigned int vID[[vertex_id]], device Vertex *pos [[buffer(0)]])
                                                                            ^
```

Adding const to ensure the buffer is read-only.