### PR TITLE
Fix issue #32 (#33)

### DIFF
--- a/include/MiniFB.h
+++ b/include/MiniFB.h
@@ -49,12 +49,12 @@ const char *    mfb_get_key_name(Key key);
 bool            mfb_is_window_active(struct Window *window);
 unsigned        mfb_get_window_width(struct Window *window);
 unsigned        mfb_get_window_height(struct Window *window);
-int             mfb_get_mouse_x(struct Window *window);            // Last mouse pos X
-int             mfb_get_mouse_y(struct Window *window);            // Last mouse pos Y
-float           mfb_get_mouse_scrool_x(struct Window *window);     // Mouse wheel X as a sum. When you call this function it resets.
-float           mfb_get_mouse_scrool_y(struct Window *window);     // Mouse wheel Y as a sum. When you call this function it resets.
-const uint8_t * mfb_get_mouse_button_buffer(struct Window *window);  // One byte for every button. Press (1), Release 0.
-const uint8_t * mfb_get_key_buffer(struct Window *window);           // One byte for every key. Press (1), Release 0.
+int             mfb_get_mouse_x(struct Window *window);             // Last mouse pos X
+int             mfb_get_mouse_y(struct Window *window);             // Last mouse pos Y
+float           mfb_get_mouse_scroll_x(struct Window *window);      // Mouse wheel X as a sum. When you call this function it resets.
+float           mfb_get_mouse_scroll_y(struct Window *window);      // Mouse wheel Y as a sum. When you call this function it resets.
+const uint8_t * mfb_get_mouse_button_buffer(struct Window *window); // One byte for every button. Press (1), Release 0. (up to 8 buttons)
+const uint8_t * mfb_get_key_buffer(struct Window *window);          // One byte for every key. Press (1), Release 0.
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/MiniFB_common.c
+++ b/src/MiniFB_common.c
@@ -144,7 +144,7 @@ int mfb_get_mouse_y(struct Window *window) {
 }
 
 //-------------------------------------
-float mfb_get_mouse_scrool_x(struct Window *window) {
+float mfb_get_mouse_scroll_x(struct Window *window) {
     if(window != 0x0) {
         SWindowData *window_data = (SWindowData *) window;
         return window_data->mouse_wheel_x;
@@ -153,7 +153,7 @@ float mfb_get_mouse_scrool_x(struct Window *window) {
 }
 
 //-------------------------------------
-float mfb_get_mouse_scrool_y(struct Window *window) {
+float mfb_get_mouse_scroll_y(struct Window *window) {
     if(window != 0x0) {
         SWindowData *window_data = (SWindowData *) window;
         return window_data->mouse_wheel_y;

--- a/src/wayland/WaylandMiniFB.c
+++ b/src/wayland/WaylandMiniFB.c
@@ -565,17 +565,27 @@ mfb_open(const char *title, unsigned width, unsigned height)
     int fd = -1;
 
     SWindowData *window_data = (SWindowData *) malloc(sizeof(SWindowData));
+    if(window_data == 0x0) {
+        return 0x0;
+    }
     memset(window_data, 0, sizeof(SWindowData));
 
     SWindowData_Way *window_data_way = (SWindowData_Way *) malloc(sizeof(SWindowData_Way));
+    if(window_data_way == 0x0) {
+        free(window_data);
+        return 0x0;
+    }
     memset(window_data_way, 0, sizeof(SWindowData_Way));
     window_data->specific = window_data_way;
 
     window_data_way->shm_format = -1u;
 
     window_data_way->display = wl_display_connect(0x0);
-    if (!window_data_way->display)
+    if (!window_data_way->display) {
+        free(window_data);
+        free(window_data_way);
         return 0x0;
+    }
     window_data_way->registry = wl_display_get_registry(window_data_way->display);
     wl_registry_add_listener(window_data_way->registry, &registry_listener, window_data);
 

--- a/src/windows/WinMiniFB.c
+++ b/src/windows/WinMiniFB.c
@@ -69,14 +69,14 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam) 
         case WM_SYSKEYUP:
         {
             if (window_data) {
-                Key key_code            = translate_key((unsigned int)wParam, (unsigned long)lParam);
-                int is_pressed         = !((lParam >> 31) & 1);
+                Key key_code          = translate_key((unsigned int)wParam, (unsigned long)lParam);
+                int is_pressed        = !((lParam >> 31) & 1);
                 window_data->mod_keys = translate_mod();
 
                 if (key_code == KB_KEY_UNKNOWN)
                     return FALSE;
 
-                window_data->key_status[key_code] = is_pressed;
+                window_data->key_status[key_code] = (uint8_t) is_pressed;
                 kCall(keyboard_func, key_code, window_data->mod_keys, is_pressed);
             }
             break;
@@ -221,14 +221,21 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam) 
 
 struct Window *mfb_open_ex(const char *title, unsigned width, unsigned height, unsigned flags) {
     RECT rect = { 0 };
-    int  x, y;
+    int  x = 0, y = 0;
 
     init_keycodes();
 
     SWindowData *window_data = malloc(sizeof(SWindowData));
+    if (window_data == 0x0) {
+        return 0x0;
+    }
     memset(window_data, 0, sizeof(SWindowData));
 
     SWindowData_Win *window_data_win = malloc(sizeof(SWindowData_Win));
+    if(window_data_win == 0x0) {
+        free(window_data);
+        return 0x0;
+    }
     memset(window_data_win, 0, sizeof(SWindowData_Win));
     window_data->specific = window_data_win;
 
@@ -239,8 +246,6 @@ struct Window *mfb_open_ex(const char *title, unsigned width, unsigned height, u
     s_window_style = WS_OVERLAPPEDWINDOW & ~WS_MAXIMIZEBOX & ~WS_THICKFRAME;
     if (flags & WF_FULLSCREEN) {
         flags = WF_FULLSCREEN;  // Remove all other flags
-        x = 0;
-        y = 0;
         rect.right  = GetSystemMetrics(SM_CXSCREEN);
         rect.bottom = GetSystemMetrics(SM_CYSCREEN);
         s_window_style = WS_POPUP & ~(WS_CAPTION | WS_THICKFRAME | WS_MINIMIZE | WS_MAXIMIZE | WS_SYSMENU);
@@ -284,8 +289,6 @@ struct Window *mfb_open_ex(const char *title, unsigned width, unsigned height, u
             rect.bottom += (rect.bottom - height);
             rect.top = 0;
         }
-        x = 0;
-        y = 0;
     }
     else if (!(flags & WF_FULLSCREEN)) {
         rect.right  = width;
@@ -323,8 +326,11 @@ struct Window *mfb_open_ex(const char *title, unsigned width, unsigned height, u
         window_data->window_width, window_data->window_height,
         0, 0, 0, 0);
 
-    if (!window_data_win->window)
+    if (!window_data_win->window) {
+        free(window_data);
+        free(window_data_win);
         return 0x0;
+    }
 
     SetWindowLongPtr(window_data_win->window, GWLP_USERDATA, (LONG_PTR) window_data);
 
@@ -334,6 +340,11 @@ struct Window *mfb_open_ex(const char *title, unsigned width, unsigned height, u
     ShowWindow(window_data_win->window, SW_NORMAL);
 
     window_data_win->bitmapInfo = (BITMAPINFO *) calloc(1, sizeof(BITMAPINFOHEADER) + sizeof(RGBQUAD) * 3);
+    if(window_data_win->bitmapInfo == 0x0) {
+        free(window_data);
+        free(window_data_win);
+        return 0x0;
+    }
     window_data_win->bitmapInfo->bmiHeader.biSize        = sizeof(BITMAPINFOHEADER);
     window_data_win->bitmapInfo->bmiHeader.biPlanes      = 1;
     window_data_win->bitmapInfo->bmiHeader.biBitCount    = 32;
@@ -405,6 +416,9 @@ UpdateState mfb_update_events(struct Window *window) {
 
     SWindowData_Win *window_data_win = (SWindowData_Win *) window_data->specific;
     while (window_data->close == false && PeekMessage(&msg, window_data_win->window, 0, 0, PM_REMOVE)) {
+        if(msg.message == WM_PAINT)
+            return;
+
         TranslateMessage(&msg);
         DispatchMessage(&msg);
     }


### PR DESCRIPTION
* update documentation

* Fix typo

* Added some examples

* changed window names

* Minor fix

* Added mfb_update_events to all platforms. Checked on Windows, X11 and Wayland

* simplify CMake

* Upgrade to CMake 3.5, simplify script and generalize it
Now the users only have to add_directory and link_libraries(minifb) in CMake

* Renamed typo scrool by scroll
Added some checks
Removed some warnings

* fix issue 32